### PR TITLE
fix: repair standalone boot and add a health endpoint

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,12 @@ const withNextIntl = createNextIntlPlugin();
 
 const nextConfig = {
 	output: "standalone",
+	// @swc/helpers >= 0.5.16 exposes its helpers through the `module-sync` export
+	// condition, which Node 22+ honours for require() but @vercel/nft does not, so
+	// the tracer only copies cjs/ and the standalone server crashes on boot.
+	outputFileTracingIncludes: {
+		"/**": ["node_modules/.pnpm/@swc+helpers@*/node_modules/@swc/helpers/esm/**/*"],
+	},
 	turbopack: {
 		root: path.dirname('.'),
 		rules: {

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json({ status: "ok" }, { status: 200 });
+}


### PR DESCRIPTION
## What

Two changes:

1. `outputFileTracingIncludes` in `next.config.mjs`, so the standalone build actually boots.
2. A new `GET /api/health` route handler.

## Why the container crashes

The staging pod has been in `CrashLoopBackOff` since the dependency upgrade in #75, failing at startup:

```
Error: Cannot find module '/app/node_modules/.pnpm/next@16.3.1_.../node_modules/@swc/helpers/esm/_interop_require_default.js'
```

Reproduced locally with `docker build` on current `main`. The chain:

- Next pins `@swc/helpers` to an exact version. #75 bumped `next` `^16.2.9 -> ^16.3.1`, which moved `@swc/helpers` `0.5.15 -> 0.5.23`.
- `0.5.15` exported `{"import": "./esm/...", "default": "./cjs/..."}`. `0.5.23` inserts `"module-sync": "./esm/..."` **before** `default`.
- Node 22+ enables the `module-sync` condition for `require()`. Same specifier, different target:

  ```
  0.5.15  require('@swc/helpers/_/_interop_require_default')  ->  cjs/_interop_require_default.cjs
  0.5.23  require('@swc/helpers/_/_interop_require_default')  ->  esm/_interop_require_default.js
  ```

- `@vercel/nft`, which drives `output: "standalone"`, does not know `module-sync` (no occurrence in `next/dist/compiled/@vercel/nft/index.js`; it defaults to `conditions: ["node"]`). It traced only `cjs/`, so `esm/` never reached the image.

The generated trace confirms it — `.next/server/app/[locale]/page.js.nft.json` contained only:

```
@swc+helpers@0.5.23/node_modules/@swc/helpers/cjs/_interop_require_default.cjs
@swc+helpers@0.5.23/node_modules/@swc/helpers/package.json
```

`outputFileTracingIncludes` is the documented escape hatch for files the tracer cannot deduce statically.

## Why the health endpoint

The `staging-portfolio` and `production-portfolio` deployments declare `livenessProbe`, `readinessProbe` and `startupProbe` all `null`. Without a readiness probe, Kubernetes marks the pod Ready as soon as the process starts, so a rollout sends traffic before Next is listening, and `kubectl rollout status` reports success immediately.

There was also nothing to probe: `/api/health` returned 404 and every other path goes through `proxy.ts` and answers 307. The proxy matcher already excludes `/api`, so the new handler is reached directly.

## Verification

Rebuilt the image and booted it:

- Before: exits 1 with `MODULE_NOT_FOUND`.
- After: `✓ Ready`, 108 files present under `@swc/helpers/esm/`.
- `/api/health` → 200 in 126 ms, body `{"status":"ok"}`; `/fr` → 200; `/en` → 200; `/` → 307.

`pnpm lint` and `pnpm i18n-check` pass (3 pre-existing `noExplicitAny` warnings in `.storybook/main.ts`, untouched here).

## For the reviewer

- **The probes are not in this PR.** The k8s manifests do not live in this repo, so this only adds the endpoint to point them at. The deployment carries `keel.sh/*` annotations for auto-update on the `staging` tag but nothing pointing at a GitOps source. Suggested container spec:

  ```yaml
  startupProbe:
    httpGet: { path: /api/health, port: 3000 }
    periodSeconds: 3
    failureThreshold: 20
  readinessProbe:
    httpGet: { path: /api/health, port: 3000 }
    periodSeconds: 10
    timeoutSeconds: 3
    failureThreshold: 3
  livenessProbe:
    httpGet: { path: /api/health, port: 3000 }
    periodSeconds: 20
    timeoutSeconds: 3
    failureThreshold: 3
  ```

- **Production is currently unaffected** — it runs `:1.2.3`, built on Next 16.2.9 with helpers 0.5.15. The next tagged release would have broken it the same way.

- **Pinning `@swc/helpers` back to `0.5.15` via `pnpm.overrides` is not a good alternative**: `@swc/core@1.15.47` declares it as a peer at `>=0.5.17`, so the pin would break that peer range.

- **CI never boots the built server**, which is why this shipped. `ci.yml` runs `pnpm build` but never starts `.next/standalone/server.js`. A smoke test (`node server.js` + `curl /api/health`) would have caught it. Not included here to keep the fix focused — happy to add it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
